### PR TITLE
Fix the issue of being unable to open WeChat and system settings in score sync page on Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ app.*.map.json
 /android/app/profile
 /android/app/release
 
+# Android build intermediate C/C++ files
+/android/app/.cxx
 
 #Keystore
 release-keystore.jks

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -60,5 +60,9 @@
             <action android:name="android.intent.action.PROCESS_TEXT" />
             <data android:mimeType="text/plain" />
         </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="weixin" />
+        </intent>
     </queries>
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
 
 
     <application
-        android:label="rank_hub"
+        android:label="RankHub"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:usesCleartextTraffic="true">

--- a/lib/src/pages/lx_sync_page.dart
+++ b/lib/src/pages/lx_sync_page.dart
@@ -12,6 +12,7 @@ import 'package:jwt_decoder/jwt_decoder.dart';
 import 'package:native_flutter_proxy/native_proxy_reader.dart';
 import 'package:rank_hub/src/pages/lx_login_page.dart';
 import 'package:url_launcher/url_launcher_string.dart';
+import 'package:android_intent_plus/android_intent.dart';
 
 class LxSyncPage extends StatefulWidget {
   const LxSyncPage({super.key});
@@ -253,12 +254,27 @@ class _LxSyncPageState extends State<LxSyncPage> {
   }
 
   void _goToSystemWifiSettings() async {
-    const url = "App-Prefs:root=WIFI";
-    if (await canLaunchUrlString(url)) {
-      await launchUrlString(url);
-    } else {
+    failToOpenSystemWifiSettings() => {
       ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text("无法打开系统WiFi设置")));
+          .showSnackBar(SnackBar(content: Text("无法打开系统WiFi设置")))
+    };
+
+    const IOSUrl = "App-Prefs:root=WIFI";
+    const AndroidIntent intent = AndroidIntent(action: "android.settings.WIFI_SETTINGS");
+    if (Platform.isAndroid) {
+      try {
+        await intent.launch();
+      } catch (e) {
+        failToOpenSystemWifiSettings();
+      }
+    } else if (Platform.isIOS) {
+      try {
+        await launchUrlString(IOSUrl);
+      } catch (e) {
+        failToOpenSystemWifiSettings();
+      }
+    } else {
+      failToOpenSystemWifiSettings();
     }
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -38,6 +38,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.11.0"
+  android_intent_plus:
+    dependency: "direct main"
+    description:
+      name: android_intent_plus
+      sha256: dfc1fd3a577205ae8f11e990fb4ece8c90cceabbee56fcf48e463ecf0bd6aae3
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.3.0"
   animated_digit:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ environment:
 dependencies:
   adaptive_action_sheet: ^2.0.3
   admonitions: ^1.1.0
+  android_intent_plus: ^5.3.0
   animated_digit: ^3.2.3
   app_settings: ^5.1.1
   audioplayers: ^6.1.0


### PR DESCRIPTION
_The PR is recreated for some reasons. Source: #21_

Changes:

- Add `.cxx` folder to `.gitignore` to exclude C/C++ intermediate files generated from Android build
- Add a dependency `android_intent_plus` to help opening system Wi-Fi settings on Android
- Add an intent in `AndroidManifest.xml` to help opening WeChat scheme URL on Android
- Change the Android user-readable label as `RankHub`

**Note:** Modified the logic of opening system Wi-Fi setting. The function can work on Android but maybe iOS won't :(