### PR TITLE
Pop snackbar when saving the image on B50 export view

### DIFF
--- a/lib/src/view/maimai/lx_b50_export_view.dart
+++ b/lib/src/view/maimai/lx_b50_export_view.dart
@@ -73,7 +73,7 @@ class LxB50ExportView extends StatelessWidget {
           actions: [
             IconButton(
               icon: Icon(Icons.save),
-              onPressed: _generateAndSaveImage,
+              onPressed: () => _generateAndSaveImage(context),
             ),
           ],
         ),


### PR DESCRIPTION
Changes:

- Added a snackbar to tell the user the status of exporting B50 image to avoid confusing the user and multiple clicks that may happen in B50 export view
- Added detailed time in B50 export image filename