### PR TITLE
fix android bilibili scheme url launch fail

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -85,5 +85,9 @@
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>
         </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="bilibili"/>
+        </intent>
     </queries>
 </manifest>

--- a/lib/games/maimai/views/difficulty_detail_page.dart
+++ b/lib/games/maimai/views/difficulty_detail_page.dart
@@ -200,9 +200,7 @@ class _DifficultyDetailPageState extends ConsumerState<DifficultyDetailPage>
                                   'bilibili://search?keyword=$keyword'; // 替换为目标应用的 URL Scheme
                               final Uri uri = Uri.parse(url);
 
-                              if (await canLaunchUrl(uri)) {
-                                await launchUrl(uri);
-                              } else {
+                              if (!await launchUrl(uri)) {
                                 await browser.open(
                                   url: WebUri(
                                     "https://search.bilibili.com/video?keyword=$keyword",

--- a/lib/modules/lxns/pages/difficulty_detail_page.dart
+++ b/lib/modules/lxns/pages/difficulty_detail_page.dart
@@ -437,9 +437,7 @@ class _DifficultyDetailPageState extends State<DifficultyDetailPage>
                                   'bilibili://search?keyword=$keyword'; // 替换为目标应用的 URL Scheme
                               final Uri uri = Uri.parse(url);
 
-                              if (await canLaunchUrl(uri)) {
-                                await launchUrl(uri);
-                              } else {
+                              if (!await launchUrl(uri)) {
                                 await browser.open(
                                   url: WebUri(
                                     "https://search.bilibili.com/video?keyword=$keyword",


### PR DESCRIPTION
- Add an intent to allow the app to handle `bilibili` scheme URL on Android
- Use `launchUrl` directly to launch `bilibili` scheme URL