### PR TITLE
fix(android): failed to open TapTap while binding Phigros account

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -89,5 +89,9 @@
             <action android:name="android.intent.action.VIEW" />
             <data android:scheme="bilibili"/>
         </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="taptap"/>
+        </intent>
     </queries>
 </manifest>

--- a/lib/modules/phigros/services/phigros_login_handler.dart
+++ b/lib/modules/phigros/services/phigros_login_handler.dart
@@ -246,9 +246,7 @@ class _QRCodeLoginTabState extends State<_QRCodeLoginTab> {
 
     try {
       final uri = Uri.parse(url);
-      if (await canLaunchUrl(uri)) {
-        await launchUrl(uri, mode: LaunchMode.externalApplication);
-      } else {
+      if (!await launchUrl(uri, mode: LaunchMode.externalApplication)) {
         if (mounted) {
           ScaffoldMessenger.of(
             context,


### PR DESCRIPTION
- Add an intent to allow the app to handle `taptap` scheme URL on Android
- Use `launchUrl` directly to launch `taptap` scheme URL