### PR TITLE
chore(deps): bump phasetida_flutter to 0.3.1

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1301,11 +1301,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "0.3.0"
-      resolved-ref: "8450f348c47ce7f0370740ad3a4515a88add2563"
+      ref: "0.3.1"
+      resolved-ref: a8796799208ff6ec5882d6c0c17ba0687b2dac4f
       url: "https://github.com/phasetida/phasetida_flutter.git"
     source: git
-    version: "0.3.0"
+    version: "0.3.1"
   photo_view:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -67,7 +67,7 @@ dependencies:
   phasetida_flutter:
     git:
       url: https://github.com/phasetida/phasetida_flutter.git
-      ref: 0.3.0
+      ref: 0.3.1
   flutter_fullscreen: ^1.2.0
   simai_flutter: ^0.2.3
   fast_gbk: ^1.0.0


### PR DESCRIPTION
~~（小修小补这一块）~~
phasetida的本次更新修复了一些小bug
### flutter侧
+ 修复了Drawer中“退出谱面预览”不能使用的问题
+ 禁用了侧滑打开Drawer和侧滑返回的手势
+ 优化了音频的播放，修复了 #96 的第1个问题和第3个问题（第2个问题暂时无法修复 ~~（怀疑是SoLoud框架本身的延迟）~~ ）
### core侧
+ 调整了判定相关的部分，主要包括：
  - 修复了判定时的遍历错误
  - 将Hold音符的尾判放宽了一个8分音符的时值